### PR TITLE
change default of shared from False to None

### DIFF
--- a/agentlib/core/datamodels.py
+++ b/agentlib/core/datamodels.py
@@ -673,8 +673,8 @@ class AgentVariable(BaseVariable):
         metadata={"title": "Place where the variable has been generated"},
         converter=Source.create,
     )
-    shared: bool = field(
-        default=False,
+    shared: Optional[bool] = field(
+        default=None,
         metadata={
             "title": "shared",
             "description": "Indicates if the variable is going to be shared "


### PR DESCRIPTION
fixes bugs, where variables are not correctly set to shared, if they are provided by the user config, and also in the python config