### PR TITLE
10 add deprecation warning or fallback for old config type = syntax

### DIFF
--- a/agentlib/core/module.py
+++ b/agentlib/core/module.py
@@ -1,5 +1,7 @@
 """This module contains the base AgentModule."""
+
 from __future__ import annotations
+
 import abc
 import json
 import logging
@@ -18,19 +20,19 @@ from typing import (
 
 import pydantic
 from pydantic import field_validator, ConfigDict, BaseModel, Field, PrivateAttr
-from pydantic_core import core_schema
 from pydantic.json_schema import GenerateJsonSchema
+from pydantic_core import core_schema
 
-from agentlib.core.environment import CustomSimpyEnvironment
-from agentlib.core.errors import ConfigurationError
+import agentlib.core.logging_ as agentlib_logging
+from agentlib.core import datamodels
 from agentlib.core.datamodels import (
     AgentVariable,
     Source,
     AgentVariables,
     AttrsToPydanticAdaptor,
 )
-from agentlib.core import datamodels
-import agentlib.core.logging_ as agentlib_logging
+from agentlib.core.environment import CustomSimpyEnvironment
+from agentlib.core.errors import ConfigurationError
 from agentlib.utils.fuzzy_matching import fuzzy_match, RAPIDFUZZ_IS_INSTALLED
 from agentlib.utils.validators import (
     include_defaults_in_root,
@@ -366,6 +368,15 @@ class BaseModule(abc.ABC):
 
     @classmethod
     def get_config_type(cls) -> Type[BaseModuleConfigClass]:
+        if hasattr(cls, "config_type"):
+            raise AttributeError(
+                "The 'config_type' attribute is deprecated and has been removed. "
+                "Please use the following syntax to assign the config of your custom "
+                f"module '{cls.__name__}': \n"
+                "class MyModule(agentlib.BaseModule):\n"
+                "    config: MyConfigClass\n"
+            )
+
         return get_type_hints(cls).get("config")
 
     @abc.abstractmethod

--- a/agentlib/models/scipy_model.py
+++ b/agentlib/models/scipy_model.py
@@ -1,9 +1,10 @@
 """This module contains the ScipyStateSpaceModel class."""
+
 import logging
 from typing import Union
-from pydantic import ValidationError, model_validator
 
 import numpy as np
+from pydantic import ValidationError, model_validator
 
 from agentlib.core.errors import OptionalDependencyError
 
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 class ScipyStateSpaceModelConfig(ModelConfig):
     """Customize config of Model."""
 
-    system: Union[dict, list, tuple, signal.ltisys.StateSpaceContinuous]
+    system: Union[dict, list, tuple, signal.StateSpace]
 
     @model_validator(mode="before")
     @classmethod
@@ -98,7 +99,7 @@ class ScipyStateSpaceModel(Model):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # Check if system was correctly set up
-        assert isinstance(self.config.system, signal.ltisys.StateSpaceContinuous)
+        assert isinstance(self.config.system, signal.StateSpace)
 
     def do_step(self, *, t_start, t_sample=None):
         if t_sample is None:


### PR DESCRIPTION
Config creation now throws an error, if config_type attribute is present at config creation time.