### PR TITLE
53 queue size and 48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,18 @@
 
 - Add an option to not parse series to json in local communicator #48
 - Increase default queue size #53
-
-## 0.8.6
-
-- Fix a bug, where pandas series could not be sent over network communicators or when
-  parsing json in local communication.
 - AgentLogger has default filename back.
 - Default value for cleanup parameter in ``mas.get_results()`` and ``agent.get_results()`` is now false.
 - Simulator now properly cleans result file if specified.
 - Logging now displays the percentage of simulation time when a limit is specified.
 - Environment logging is now in the same style as module logging.
+- Fix a bug, where pandas series were parsed to string but not back when using local communicators.
+
+## 0.8.6
+
+- Fix a bug, where pandas series could not be sent over network communicators or when
+  parsing json in local communication.
+
 
 ## 0.8.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.8.7
+
+- Add an option to not parse series to json in local communicator #48
+- Increase default queue size #53
+
 ## 0.8.6
 
 - Fix a bug, where pandas series could not be sent over network communicators or when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 - Fix a bug, where pandas series could not be sent over network communicators or when
   parsing json in local communication.
+- AgentLogger has default filename back.
+- Default value for cleanup parameter in ``mas.get_results()`` and ``agent.get_results()`` is now false.
+- Simulator now properly cleans result file if specified.
+- Logging now displays the percentage of simulation time when a limit is specified.
+- Environment logging is now in the same style as module logging.
 
 ## 0.8.5
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install -e .[full]
 ```
 
 ## Optional Dependencies
-The AgentLib has a number of optional dependencies, ranging from additional features to performance improvements:
+AgentLib has a number of optional dependencies, ranging from additional features to performance improvements:
  
  - **fmu**: Support simulation of FMU models (https://fmi-standard.org/).
  - **scipy**: Support simulation of linear state space models, based on scipy.
@@ -41,6 +41,12 @@ The AgentLib has a number of optional dependencies, ranging from additional feat
  - **fuzz**: Improves error messages when providing wrong configurations.
 
 **clonemap**: Support the execution of agents and their communication through [clonemap](https://github.com/sogno-platform/clonemap). As clonemapy is not available through PYPI, please install it from source, or through the AgentLib's ``requirements.txt`` .
+
+## Plugins
+AgentLib supports extension, especially in the form of additional modules through plugins.
+Official Plugins available are:
+  - **[AgentLib_MPC](https://github.com/RWTH-EBC/AgentLib-MPC)**: Provides modules for model predictive control.
+  - **[AgentLib_FIWARE](https://github.com/RWTH-EBC/AgentLib-FIWARE)**: Provides communicators for the IoT Platform FIWARE.
 
 ## Referencing the AgentLib
 

--- a/agentlib/__init__.py
+++ b/agentlib/__init__.py
@@ -12,7 +12,7 @@ from .utils.multi_agent_system import (
     LocalCloneMAPAgency,
 )
 
-__version__ = "0.8.6"
+__version__ = "0.8.7"
 
 __all__ = [
     "core",

--- a/agentlib/core/agent.py
+++ b/agentlib/core/agent.py
@@ -282,7 +282,11 @@ class Agent:
         """
         results = {}
         for module in self.modules:
-            result = module.get_results()
+            try:
+                result = module.get_results()
+            except BaseException as e:
+                self.logger.error(f"Error reading results of module {module.id}: {e}")
+                result = None
             if result is not None:
                 results[module.id] = result
         if cleanup:

--- a/agentlib/core/agent.py
+++ b/agentlib/core/agent.py
@@ -4,9 +4,9 @@ Module containing only the Agent class.
 
 import json
 import threading
+from pathlib import Path
 from typing import Union, List, Dict, TypeVar, Optional
 
-from pathlib import Path
 from pydantic import field_validator, BaseModel, FilePath, Field
 
 import agentlib
@@ -274,7 +274,7 @@ class Agent:
                     {_module_id: module_cls(agent=self, config=module_config)}
                 )
 
-    def get_results(self, cleanup=True):
+    def get_results(self, cleanup=False):
         """
         Gets the results of this agent.
         Args:

--- a/agentlib/core/environment.py
+++ b/agentlib/core/environment.py
@@ -26,7 +26,6 @@ Simpy is distributed under the MIT License
 """
 
 import json
-import logging
 import time
 from datetime import datetime
 from pathlib import Path
@@ -41,7 +40,7 @@ from pydantic import (
 )
 from simpy.core import SimTime, Event
 
-logger = logging.getLogger(name=__name__)
+from agentlib.core import logging_ as agentlib_logging
 
 
 class EnvironmentConfig(BaseModel):
@@ -124,7 +123,7 @@ class CustomSimpyEnvironment(simpy.Environment):
         """Define a clock loop to increase the now-timer every other second
         (Or whatever t_sample is)"""
         while True:
-            logger.info("Current simulation time: %s", self.pretty_time())
+            self.logger.info("Current simulation time: %s", self.pretty_time())
             yield self.timeout(self.config.t_sample)
 
     def pretty_time(self): ...
@@ -140,6 +139,8 @@ class InstantEnvironment(CustomSimpyEnvironment):
         super().__init__(initial_time=config.offset)
         self._config = config
         self._until = None
+        # Create an environment-specific logger using CustomLogger
+        self.logger = agentlib_logging.create_logger(env=self, name="environment")
         if self.config.clock:
             self.process(self.clock())
 
@@ -169,6 +170,7 @@ class RealtimeEnvironment(simpy.RealtimeEnvironment, CustomSimpyEnvironment):
         )
         self._until = None
         self._config = config
+        self.logger = agentlib_logging.create_logger(env=self, name="environment")
         if self.config.clock:
             self.process(self.clock())
         else:
@@ -212,6 +214,7 @@ class ScaledRealtimeEnvironment(simpy.RealtimeEnvironment, CustomSimpyEnvironmen
         )
         self._config = config
         self._until = None
+        self.logger = agentlib_logging.create_logger(env=self, name="environment")
         if self.config.clock:
             self.process(self.clock())
         else:

--- a/agentlib/core/logging_.py
+++ b/agentlib/core/logging_.py
@@ -32,7 +32,8 @@ class CustomLogger(logging.Logger):
         _until = self.env.pretty_until()
         _time = self.env.pretty_time()
         if _until is None:
-            record.env_time = _time
+            # Add "INIT" prefix to clearly indicate initialization phase
+            record.env_time = f"<INIT> {_time}"
         else:
             record.env_time = _time + "/" + _until
         return record

--- a/agentlib/core/logging_.py
+++ b/agentlib/core/logging_.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING
 
+from agentlib.core import environment
+
 if TYPE_CHECKING:
     from agentlib import Environment
 
@@ -31,9 +33,11 @@ class CustomLogger(logging.Logger):
         )
         _until = self.env.pretty_until()
         _time = self.env.pretty_time()
-        if _until is None:
+        if _until is environment.UNTIL_UNSET:
             # Add "INIT" prefix to clearly indicate initialization phase
-            record.env_time = f"<INIT> {_time}"
+            record.env_time = f"<INIT>"
+        elif _until is None:
+            record.env_time = _time
         else:
             record.env_time = _time + "/" + _until
         return record
@@ -57,9 +61,9 @@ def create_logger(env: "Environment", name: str) -> CustomLogger:
     for handler in logging.root.handlers:
         if isinstance(handler, logging.FileHandler):
             # Create a similar FileHandler for our custom logger
-            file_handler = logging.FileHandler(handler.baseFilename,
-                                               mode=handler.mode,
-                                               encoding=handler.encoding)
+            file_handler = logging.FileHandler(
+                handler.baseFilename, mode=handler.mode, encoding=handler.encoding
+            )
             file_handler.setFormatter(formatter)
             file_handler.setLevel(handler.level)
             custom_logger.addHandler(file_handler)

--- a/agentlib/core/logging_.py
+++ b/agentlib/core/logging_.py
@@ -46,4 +46,16 @@ def create_logger(env: "Environment", name: str) -> CustomLogger:
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
     custom_logger.addHandler(stream_handler)
+
+    # Check if root logger has any FileHandlers and add similar ones to our custom logger
+    for handler in logging.root.handlers:
+        if isinstance(handler, logging.FileHandler):
+            # Create a similar FileHandler for our custom logger
+            file_handler = logging.FileHandler(handler.baseFilename,
+                                               mode=handler.mode,
+                                               encoding=handler.encoding)
+            file_handler.setFormatter(formatter)
+            file_handler.setLevel(handler.level)
+            custom_logger.addHandler(file_handler)
+
     return custom_logger

--- a/agentlib/core/logging_.py
+++ b/agentlib/core/logging_.py
@@ -29,7 +29,12 @@ class CustomLogger(logging.Logger):
         record = super().makeRecord(
             name, level, fn, lno, msg, args, exc_info, func, extra, sinfo
         )
-        record.env_time = self.env.pretty_time()
+        _until = self.env.pretty_until()
+        _time = self.env.pretty_time()
+        if _until is None:
+            record.env_time = _time
+        else:
+            record.env_time = _time + "/" + _until
         return record
 
 

--- a/agentlib/modules/communicator/communicator.py
+++ b/agentlib/modules/communicator/communicator.py
@@ -150,6 +150,11 @@ class LocalCommunicatorConfig(CommunicatorConfig):
         title="Size of the queue",
         default=10000
     )
+    parse_series_to_json: bool = Field(
+        title="parse_series_to_json",
+        default=False,
+        description="If true, thee default, all pd.Series values will be converted to json before being send."
+    )
 
 
 class LocalCommunicator(Communicator):

--- a/agentlib/modules/simulation/simulator.py
+++ b/agentlib/modules/simulation/simulator.py
@@ -494,6 +494,12 @@ class Simulator(BaseModule):
         df = df.droplevel(level=2, axis=1).droplevel(level=0, axis=1)
         return df
 
+    def cleanup_results(self):
+        if not self.config.save_results or not self.config.result_filename:
+            return
+        os.remove(self.config.result_filename)
+
+
     def _update_results(self):
         """
         Adds model variables to the SimulationResult object

--- a/agentlib/modules/utils/agent_logger.py
+++ b/agentlib/modules/utils/agent_logger.py
@@ -42,7 +42,7 @@ class AgentLoggerConfig(BaseModuleConfig):
     overwrite_log: bool = Field(
         title="Overwrite file",
         default=False,
-        description="If true, old logs are auto deleted when a new log should be written with that name."
+        description="If true, old logs are auto deleted when a new log should be written with that name.",
     )
     filename: Optional[str] = Field(
         title="filename",
@@ -75,6 +75,7 @@ class AgentLoggerConfig(BaseModuleConfig):
         # Create path in case it does not exist
         file_path.parent.mkdir(parents=True, exist_ok=True)
         return filename
+
 
 class AgentLogger(BaseModule):
     """

--- a/agentlib/modules/utils/agent_logger.py
+++ b/agentlib/modules/utils/agent_logger.py
@@ -73,8 +73,7 @@ class AgentLoggerConfig(BaseModuleConfig):
                 f"activate automatic overwrite."
             )
         # Create path in case it does not exist
-        if file_path.parent.name:  # Check if parent directory exists
-            file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
         return filename
 
 class AgentLogger(BaseModule):

--- a/agentlib/modules/utils/agent_logger.py
+++ b/agentlib/modules/utils/agent_logger.py
@@ -5,8 +5,10 @@ import collections
 import json
 import logging
 import os
+import time
 from ast import literal_eval
-from typing import Union
+from pathlib import Path
+from typing import Union, Optional
 
 import pandas as pd
 from pydantic import field_validator, Field
@@ -42,9 +44,10 @@ class AgentLoggerConfig(BaseModuleConfig):
         default=False,
         description="If true, old logs are auto deleted when a new log should be written with that name."
     )
-    filename: str = Field(
+    filename: Optional[str] = Field(
         title="filename",
-        description="The filename where the log is stored.",
+        default=None,
+        description="The filename where the log is stored. If None, will use 'agent_logs/{agent_id}_log.json'",
     )
 
     @field_validator("filename")
@@ -52,10 +55,16 @@ class AgentLoggerConfig(BaseModuleConfig):
     def check_existence_of_file(cls, filename, info: FieldValidationInfo):
         """Checks whether the file already exists."""
         # pylint: disable=no-self-argument,no-self-use
-        if os.path.isfile(filename):
+
+        # Skip check for None, as it will be replaced in __init__
+        if filename is None:
+            return filename
+
+        file_path = Path(filename)
+        if file_path.exists():
             # remove result file, so a new one can be created
             if info.data["overwrite_log"]:
-                os.remove(filename)
+                file_path.unlink()
                 return filename
             raise FileExistsError(
                 f"Given filename at {filename} "
@@ -64,11 +73,9 @@ class AgentLoggerConfig(BaseModuleConfig):
                 f"activate automatic overwrite."
             )
         # Create path in case it does not exist
-        fpath = os.path.dirname(filename)
-        if fpath:
-            os.makedirs(fpath, exist_ok=True)
+        if file_path.parent.name:  # Check if parent directory exists
+            file_path.parent.mkdir(parents=True, exist_ok=True)
         return filename
-
 
 class AgentLogger(BaseModule):
     """
@@ -79,10 +86,23 @@ class AgentLogger(BaseModule):
     config: AgentLoggerConfig
 
     def __init__(self, *, config: dict, agent: Agent):
-        """Overwrite init to enable a custom default filename
-        which uses the agent_id."""
         super().__init__(config=config, agent=agent)
-        self._filename = self.config.filename
+
+        # If filename is None, create a custom one using the agent ID
+        if self.config.filename is None:
+            # Use agent ID to create a default filename
+            logs_dir = Path("agent_logs")
+            logs_dir.mkdir(exist_ok=True)
+            self._filename = str(logs_dir / f"{self.agent.id}.jsonl")
+
+            # Handle file exists case based on overwrite_log setting
+            if Path(self._filename).exists() and not self.config.overwrite_log:
+                # Generate a unique filename by appending a timestamp
+                timestamp = int(time.time())
+                self._filename = str(logs_dir / f"{self.agent.id}_{timestamp}.jsonl")
+        else:
+            self._filename = self.config.filename
+
         self._variables_to_log = {}
         if not self.env.config.rt and self.config.t_sample < 60:
             self.logger.warning(

--- a/agentlib/modules/utils/try_sensor.py
+++ b/agentlib/modules/utils/try_sensor.py
@@ -3,7 +3,7 @@ from the Deutsche Wetterdienst (DWD)."""
 
 import io
 from typing import Union, List
-from pydantic import FilePath, Field, validator
+from pydantic import FilePath, Field
 import numpy as np
 import pandas as pd
 from agentlib.core import (

--- a/agentlib/utils/multi_agent_system.py
+++ b/agentlib/utils/multi_agent_system.py
@@ -181,7 +181,7 @@ class LocalMASAgency(MAS):
         except KeyError:
             KeyError(f"Given id '{id}' is not in the set of agents.")
 
-    def get_results(self, cleanup: bool = True) -> Dict[str, pd.DataFrame]:
+    def get_results(self, cleanup: bool = False) -> Dict[str, pd.DataFrame]:
         """
         Get all results of the agentLogger
         Args:

--- a/agentlib/utils/plotting/simulator_dashboard.py
+++ b/agentlib/utils/plotting/simulator_dashboard.py
@@ -9,8 +9,8 @@ from agentlib.core.errors import OptionalDependencyError
 
 try:
     import dash
-    from dash import dcc, html, callback_context
-    from dash.dependencies import Input, Output, State, ALL, ClientsideFunction
+    from dash import dcc, html
+    from dash.dependencies import Input, Output, State, ALL
     import dash_bootstrap_components as dbc
     import plotly.graph_objs as go
 except ImportError:

--- a/ci/run_examples.py
+++ b/ci/run_examples.py
@@ -5,10 +5,7 @@ import unittest
 import os
 import subprocess
 import logging
-import os
 import pathlib
-import subprocess
-import unittest
 
 import pandas as pd
 

--- a/examples/getting-started/part_3_using_models_with_comments.py
+++ b/examples/getting-started/part_3_using_models_with_comments.py
@@ -32,9 +32,6 @@ import agentlib as ag
 
 
 # define the inputs, outputs, states and parameters of your model
-from agentlib.utils.multi_agent_system import LocalMASAgency
-
-
 class HeatedRoomConfig(ag.ModelConfig):
     inputs: List[ag.ModelInput] = [
         ag.ModelInput(name="heating_power_in_watt", value=100)

--- a/examples/multi-agent-systems/room_mas/room_mas.py
+++ b/examples/multi-agent-systems/room_mas/room_mas.py
@@ -31,7 +31,7 @@ def run_example(until, with_plots=True, log_level=logging.INFO):
     # Simulate
     mas.run(until=until)
     # Load results:
-    results = mas.get_results()
+    results = mas.get_results(cleanup=True)
 
     if not with_plots:
         return results

--- a/tests/test_communicator.py
+++ b/tests/test_communicator.py
@@ -47,7 +47,9 @@ class TestCommunicator(unittest.TestCase):
         data = {**default_data, "value": pd.Series({0: 1, 10: 2}), "type": "pd.Series"}
         variable = AgentVariable(**data)
         comm_parse = LocalClient(config=self.test_config, agent=self.agent_send)
-        comm_no_parse = LocalClient(config={**self.test_config, "parse_json": False}, agent=self.agent_send)
+        comm_no_parse = LocalClient(
+            config={**self.test_config, "parse_json": False}, agent=self.agent_send
+        )
 
         # communicator with json parsing
         payload = comm_parse.short_dict(variable)
@@ -56,7 +58,9 @@ class TestCommunicator(unittest.TestCase):
         pd.testing.assert_series_equal(variable.value, variable2.value)
 
         # communicator without json parsing
-        payload = comm_no_parse.short_dict(variable, parse_json=comm_no_parse.config.parse_json)
+        payload = comm_no_parse.short_dict(
+            variable, parse_json=comm_no_parse.config.parse_json
+        )
         payload["name"] = payload["alias"]
         variable2 = AgentVariable(**payload)
         pd.testing.assert_series_equal(variable.value, variable2.value)
@@ -68,7 +72,7 @@ class TestCommunicator(unittest.TestCase):
         _config = self.test_config.copy()
         _config["parse_json"] = False
         comm = LocalClient(config=_config, agent=self.agent_send)
-        payload = comm.short_dict(variable)
+        payload = comm.short_dict(variable, parse_json=comm.config.parse_json)
         pd.testing.assert_series_equal(variable.value, payload["value"])
 
 

--- a/tests/test_communicator.py
+++ b/tests/test_communicator.py
@@ -25,7 +25,7 @@ class TestCommunicator(unittest.TestCase):
         self.test_config = {
             "type": "local_broadcast",
             "module_id": "comm_module",
-            "parse_json": True,
+            "parse_json": True
         }
         self.agent_send = Agent(config={"id": "Send", "modules": []}, env=Environment())
         self.agent_rec = Agent(config={"id": "Rec", "modules": []}, env=Environment())
@@ -51,6 +51,16 @@ class TestCommunicator(unittest.TestCase):
         var_json = comm.to_json(payload)
         variable2 = AgentVariable.from_json(var_json)
         pd.testing.assert_series_equal(variable.value, variable2.value)
+
+    def test_pd_series_no_json(self):
+        """Tests whether pandas series are sent correctly"""
+        data = {**default_data, "value": pd.Series({0: 1, 10: 2}), "type": "pd.Series"}
+        variable = AgentVariable(**data)
+        _config = self.test_config.copy()
+        _config["parse_json"] = False
+        comm = LocalClient(config=_config, agent=self.agent_send)
+        payload = comm.short_dict(variable)
+        pd.testing.assert_series_equal(variable.value, payload["value"])
 
 
 if __name__ == "__main__":

--- a/tests/test_databroker_limits.py
+++ b/tests/test_databroker_limits.py
@@ -3,9 +3,7 @@
 import time
 import unittest
 
-import time
 
-import numpy as np
 
 from agentlib import LocalMASAgency
 from agentlib import AgentVariable, BaseModule, BaseModuleConfig

--- a/tests/test_datamodels.py
+++ b/tests/test_datamodels.py
@@ -1,8 +1,7 @@
 """Module to test all datamodels in the agentlib"""
 
 import unittest
-from pydantic import ValidationError
-from agentlib.core import datamodels, errors
+from agentlib.core import datamodels
 import pandas as pd
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -85,7 +85,7 @@ class TestModel(unittest.TestCase):
     def test_abc(self):
         """Test if abc evokes error"""
         with self.assertRaises(TypeError):
-            model = Model()
+            Model()
 
     def test_get_attr(self):
         """Test if AttributeError is evoked"""

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -253,7 +253,7 @@ class TestModule(unittest.TestCase):
     def test_missing_config_type(self):
         """Tests if a proper error is raised when the type is missing."""
         with self.assertRaises(ConfigurationError):
-            mod = BrokenCustomModule(config=self.test_config, agent=self.agent)
+            BrokenCustomModule(config=self.test_config, agent=self.agent)
 
     def test_properties(self):
         """Test properties of module"""


### PR DESCRIPTION
Closes #53 and addresses #48

@EserSteffen This also adapts the file-handler from the root logger for the agent logger. Now, you can do multiprocessing with agents and assign a file-log based on the agent name. 
You may change the default q-size, but I don't see why we should set the default to 100.

Maybe we need to force the config for communicators which require json, but I think the modules should decide on it.